### PR TITLE
플레이어 동시에 서로를 죽였을 때 버그 픽스 / 플레이어 죽고나서 y값 변경되는 버그 픽스

### DIFF
--- a/Assets/02.Scripts/Character/Skull.cs
+++ b/Assets/02.Scripts/Character/Skull.cs
@@ -210,18 +210,9 @@ namespace HideAndSkull.Character
                 _canAction = false;
                 isDead = true;
                 _currentAct = ActFlag.Die;
-
-                if (PhotonNetwork.IsMasterClient && PlayMode == PlayMode.Player)
-                {
-                    UI_ToastPanel uI_ToastPanel = UI_Manager.instance.Resolve<UI_ToastPanel>();
-                    uI_ToastPanel.ShowToast($"{PhotonView.Owner.NickName}님이 사망하였습니다.");
-
-                    PlayerCustomProperty["IsDead"] = true;
-
-                    PhotonView.Owner.SetCustomProperties(PlayerCustomProperty);
-                }
-
                 _animator.SetTrigger(IsDead);
+
+                this.gameObject.GetComponent<Rigidbody>().isKinematic = true;
             }
         }
 

--- a/Assets/02.Scripts/Character/Sword.cs
+++ b/Assets/02.Scripts/Character/Sword.cs
@@ -1,4 +1,6 @@
-﻿using Photon.Pun;
+﻿using HideAndSkull.Lobby.UI;
+using HideAndSkull.Survivors.UI;
+using Photon.Pun;
 using UnityEngine;
 
 namespace HideAndSkull.Character
@@ -10,14 +12,22 @@ namespace HideAndSkull.Character
         private void OnTriggerEnter(Collider other)
         {
             //맞았는지 판단은 MasterClient에서만 함
-            if(PhotonNetwork.IsMasterClient)
+            if(other.TryGetComponent(out PhotonView photonView) && 
+               photonView.IsMine)
             {
                 if (other.TryGetComponent(out Skull skull))
                 {
-                    //MasterClient에서 맞았다고 판단되면 모든 플레이어에게 해당 character가 죽었다고 호출함
-                    skull.PhotonView.RPC(nameof(skull.Die), RpcTarget.AllViaServer);
+                    if (skull.isDead)
+                        return;
 
-                    if(skull.PlayMode == PlayMode.Player && skull.isDead == false)
+                    //MasterClient에서 맞았다고 판단되면 모든 플레이어에게 해당 character가 죽었다고 호출함
+                    skull.PhotonView.RPC(nameof(skull.Die), RpcTarget.All);
+                    skull.PlayerCustomProperty["IsDead"] = true;
+                    photonView.Owner.SetCustomProperties(skull.PlayerCustomProperty);
+                    UI_ToastPanel uI_ToastPanel = UI_Manager.instance.Resolve<UI_ToastPanel>();
+                    uI_ToastPanel.ShowToast($"{photonView.Owner.NickName}님이 사망하였습니다.");
+
+                    if (skull.PlayMode == PlayMode.Player)
                     {
                         int killcount = (int)Owner.PlayerCustomProperty["KillCount"];
                         Owner.PlayerCustomProperty["KillCount"] = killcount + 1;


### PR DESCRIPTION
플레이어 동시에 서로를 죽였을 때 버그 픽스
플레이어 isDead를 MasterClient가 아닌 죽은 플레이어가 값을 갱신할 수 있도록 Skull.cs -> Sword.cs로 이동

플레이어가 죽고나서 y값 변경되는 버그 픽스
플레이어가 죽었을 때, rigidbody.isKinematic = true로 변경